### PR TITLE
Ensure the destination directory exists when copying a file

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -4,25 +4,33 @@
 
 ### Added
 - Added `TestResponse::assertJsonPath()` method ([#29957](https://github.com/laravel/framework/pull/29957))
+- Added `hasMacro` \ `getGlobalMacro` \ `hasGlobalMacro` methods to `Eloquent Builder` ([#30008](https://github.com/laravel/framework/pull/30008))
+- Added `Illuminate\Database\Eloquent\Relations\BelongsToMany::getPivotColumns()` method ([#30049](https://github.com/laravel/framework/pull/30049)) 
+- Added `ScheduledTaskFinished` \ `ScheduledTaskStarting` events to signal when scheduled task runs ([#29888](https://github.com/laravel/framework/pull/29888))
 
 ### Fixed
 - Fixed `__()` with `null` parameter ([#29967](https://github.com/laravel/framework/pull/29967)) 
 - Fixed modifying `updated_at` column on custom pivot model ([#29970](https://github.com/laravel/framework/pull/29970))
+- Fixed `Illuminate\Redis\Limiters\ConcurrencyLimiter` ([#30005](https://github.com/laravel/framework/pull/30005))
+- Fixed `VerifyCsrfToken` middleware when response object instance of `Responsable` interface ([#29972](https://github.com/laravel/framework/pull/29972))
+- Fixed Postgresql column creation without optional precision ([#29873](https://github.com/laravel/framework/pull/29873))
 
 ### Changed
 - Make it possible to disable encryption via `0`/`false` ([#29985](https://github.com/laravel/framework/pull/29985))
+- Allowed a symfony file instance in validate dimensions ([#30009](https://github.com/laravel/framework/pull/30009))
+- Create storage fakes with custom configuration ([#29999](https://github.com/laravel/framework/pull/29999))
 
 ### Refactoring
 - Changed imports to Alpha ordering in stubs ([#29954](https://github.com/laravel/framework/pull/29954), [#29958](https://github.com/laravel/framework/pull/29958))
 - Used value helper where possible ([#29959](https://github.com/laravel/framework/pull/29959))
+- Improved readability in `auth.throttle` translation ([#30011](https://github.com/laravel/framework/pull/30011), [#30017](https://github.com/laravel/framework/pull/30017))
 
 ### TODO:
-- Sort imports alphabetically on class generation from stub ([#29951](https://github.com/laravel/framework/pull/29951))
-- Convert Responsables to Response objects in VerifyCsrfToken ([#29972](https://github.com/laravel/framework/pull/29972))
-- Allow adding NotFoundHttpException to "allowed" exceptions in tests ([#29975](https://github.com/laravel/framework/pull/29975))
-- Add events to signal when scheduled task runs ([#29888](https://github.com/laravel/framework/pull/29888))
-- Postgresql column precision declaration fix ([#29873](https://github.com/laravel/framework/pull/29873))
 - Allow adding command arguments and options with objects ([#29987](https://github.com/laravel/framework/pull/29987))
+- Fix Migrations out of order with multiple path with certain filenames ([#29996](https://github.com/laravel/framework/pull/29996))
+- Set locale conditionally ([dd1e0a6](https://github.com/laravel/framework/commit/dd1e0a604713ddae21e6a893e4f605a6777300e8))
+- Sort imports alphabetically on class generation from stub ([#29951](https://github.com/laravel/framework/pull/29951))
+- Allow adding NotFoundHttpException to "allowed" exceptions in tests ([#29975](https://github.com/laravel/framework/pull/29975))
 
 
 ## [v6.0.3 (2019-09-10)](https://github.com/laravel/framework/compare/v6.0.2...v6.0.3)

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -111,7 +111,7 @@ class Response implements Arrayable
      *
      * @return \Illuminate\Auth\Access\Response
      *
-     * @throws AuthorizationException
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function authorize()
     {

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -133,7 +133,7 @@ trait Queueable
     /**
      * Specify the middleware the job should be dispatched through.
      *
-     * @param  array|object
+     * @param  array|object  $middleware
      * @return $this
      */
     public function through($middleware)

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -555,7 +555,7 @@ class Event
      * Get the callback that pings the given URL.
      *
      * @param  string  $url
-     * @return Closure
+     * @return \Closure
      */
     protected function pingCallback($url)
     {

--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -42,7 +42,7 @@ interface Filesystem
      * @param  string  $path
      * @return resource|null The path resource or null on failure.
      *
-     * @throws FileNotFoundException
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function readStream($path);
 
@@ -65,7 +65,7 @@ interface Filesystem
      * @return bool
      *
      * @throws \InvalidArgumentException If $resource is not a file handle.
-     * @throws FileExistsException
+     * @throws \Illuminate\Contracts\Filesystem\FileExistsException
      */
     public function writeStream($path, $resource, array $options = []);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1264,6 +1264,39 @@ class Builder
     }
 
     /**
+     * Checks if a macro is registered.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasMacro($name)
+    {
+        return isset($this->localMacros[$name]);
+    }
+
+    /**
+     * Get the given global macro by name.
+     *
+     * @param  string  $name
+     * @return \Closure
+     */
+    public static function getGlobalMacro($name)
+    {
+        return Arr::get(static::$macros, $name);
+    }
+
+    /**
+     * Checks if a global macro is registered.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public static function hasGlobalMacro($name)
+    {
+        return isset(static::$macros[$name]);
+    }
+
+    /**
      * Dynamically access builder proxies.
      *
      * @param  string  $key
@@ -1295,13 +1328,13 @@ class Builder
             return;
         }
 
-        if (isset($this->localMacros[$method])) {
+        if ($this->hasMacro($method)) {
             array_unshift($parameters, $this);
 
             return $this->localMacros[$method](...$parameters);
         }
 
-        if (isset(static::$macros[$method])) {
+        if (static::hasGlobalMacro($method)) {
             if (static::$macros[$method] instanceof Closure) {
                 return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
             }
@@ -1339,7 +1372,7 @@ class Builder
             return;
         }
 
-        if (! isset(static::$macros[$method])) {
+        if (! static::hasGlobalMacro($method)) {
             static::throwBadMethodCallException($method);
         }
 

--- a/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
+++ b/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
@@ -24,7 +24,7 @@ class HigherOrderBuilderProxy
     /**
      * Create a new proxy instance.
      *
-     * @param Builder $builder
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
      * @param string $method
      */
     public function __construct(Builder $builder, $method)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1133,4 +1133,14 @@ class BelongsToMany extends Relation
     {
         return $this->accessor;
     }
+
+    /**
+     * Get the pivot columns for this relationship.
+     *
+     * @return array
+     */
+    public function getPivotColumns()
+    {
+        return $this->pivotColumns;
+    }
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1026,13 +1026,13 @@ class Builder
     /**
      * Add a "where not null" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $columns
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function whereNotNull($column, $boolean = 'and')
+    public function whereNotNull($columns, $boolean = 'and')
     {
-        return $this->whereNull($column, $boolean, true);
+        return $this->whereNull($columns, $boolean, true);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -236,6 +236,10 @@ class Filesystem
      */
     public function copy($path, $target)
     {
+        if (! $this->exists(dirname($target))) {
+            $this->makeDirectory(dirname($target), 0755, true, true);
+        }
+        
         return copy($path, $target);
     }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -606,7 +606,7 @@ class Str
     /**
      * Set the callable that will be used to generate UUIDs.
      *
-     * @param  callable
+     * @param  callable  $factory
      * @return void
      */
     public static function createUuidsUsing(callable $factory = null)

--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -3,9 +3,7 @@
 namespace Illuminate\Validation\Concerns;
 
 use Egulias\EmailValidator\EmailLexer;
-use Egulias\EmailValidator\Exception\InvalidEmail;
 use Egulias\EmailValidator\Validation\EmailValidation;
-use Egulias\EmailValidator\Warning\Warning;
 
 class FilterEmailValidation implements EmailValidation
 {
@@ -13,7 +11,7 @@ class FilterEmailValidation implements EmailValidation
      * Returns true if the given email is valid.
      *
      * @param  string  $email
-     * @param  EmailLexer
+     * @param  \Egulias\EmailValidator\EmailLexer  $emailLexer
      * @return bool
      */
     public function isValid($email, EmailLexer $emailLexer)
@@ -24,7 +22,7 @@ class FilterEmailValidation implements EmailValidation
     /**
      * Returns the validation error.
      *
-     * @return InvalidEmail|null
+     * @return \Egulias\EmailValidator\Exception\InvalidEmail|null
      */
     public function getError()
     {
@@ -34,7 +32,7 @@ class FilterEmailValidation implements EmailValidation
     /**
      * Returns the validation warnings.
      *
-     * @return Warning[]
+     * @return \Egulias\EmailValidator\Warning\Warning[]
      */
     public function getWarnings()
     {

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -94,7 +94,7 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
     /**
      * Get a database connection instance.
      *
-     * @return Connection
+     * @return \Illuminate\Database\ConnectionInterface
      */
     protected function connection()
     {
@@ -104,7 +104,7 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
     /**
      * Get a schema builder instance.
      *
-     * @return Schema\Builder
+     * @return \Illuminate\Database\Schema\Builder
      */
     protected function schema()
     {

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -92,7 +92,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
     /**
      * Get a database connection instance.
      *
-     * @return Connection
+     * @return \Illuminate\Database\ConnectionInterface
      */
     protected function connection()
     {
@@ -102,7 +102,7 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
     /**
      * Get a schema builder instance.
      *
-     * @return Schema\Builder
+     * @return \Illuminate\Database\Schema\Builder
      */
     protected function schema()
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -431,6 +431,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
         $result = $builder->fooBar();
 
+        $this->assertTrue($builder->hasMacro('fooBar'));
         $this->assertEquals($builder, $result);
         $this->assertEquals($builder, $_SERVER['__test.builder']);
         unset($_SERVER['__test.builder']);
@@ -446,6 +447,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
 
+        $this->assertTrue(Builder::hasGlobalMacro('foo'));
         $this->assertEquals($builder->foo('bar'), 'bar');
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }

--- a/tests/Integration/Auth/Fixtures/AuthenticationTestUser.php
+++ b/tests/Integration/Auth/Fixtures/AuthenticationTestUser.php
@@ -10,7 +10,7 @@ class AuthenticationTestUser extends Authenticatable
     public $timestamps = false;
 
     /**
-     * The attributes that are mass assignable.
+     * The attributes that aren't mass assignable.
      *
      * @var array
      */

--- a/tests/Validation/ValidationAddFailureTest.php
+++ b/tests/Validation/ValidationAddFailureTest.php
@@ -10,7 +10,7 @@ class ValidationAddFailureTest extends TestCase
     /**
      * Making Validator using ValidationValidatorTest.
      *
-     * @return Validator
+     * @return \Illuminate\Validation\Validator
      */
     public function makeValidator()
     {


### PR DESCRIPTION
When you copy a file "/dir1/a.txt" to "/dir2/b.txt" while "/dir2" doesn't exist, you'll get an error "failed to open stream: No such file or directory".

Instead, I suggest we make the copy function behave the same way as copyDirectory() and create all the destination folders if needed.

Since there's a slight chance that someone relies on this function throwing an exception, I'm submitting this to master, however, this chance sounds ridiculous to me.